### PR TITLE
Add remainder of control schema

### DIFF
--- a/test/turbine_example.yaml
+++ b/test/turbine_example.yaml
@@ -450,6 +450,11 @@ control:
         ss_vsgain: 1    
         ss_pcgain: .001 
 
+    soft_cut_out:
+        wind_speeds: [0,10,20,40]
+        power_reference: [1,1,.7,0]
+
+
     shutdown:
         limit_type: pitch
         limit_value:  .3

--- a/windIO/turbine/IEAontology_schema.yaml
+++ b/windIO/turbine/IEAontology_schema.yaml
@@ -2018,12 +2018,10 @@ properties:
                         $ref: "#/definitions/state_space"
                     activator:
                         $ref: "#/definitions/activator"
-
             user_defined_SS_2: *uss
             user_defined_SS_3: *uss
             user_defined_SS_4: *uss
-            user_defined_SS_5: *uss   # can add more...
-
+            user_defined_SS_5: *uss
             user_defined_TF_1: &u_tf
                 type: object
                 description: User defined transfer function linear controllers within ROSCO, only 1 for now
@@ -2047,8 +2045,7 @@ properties:
             user_defined_TF_2: *u_tf
             user_defined_TF_3: *u_tf
             user_defined_TF_4: *u_tf
-            user_defined_TF_5: *u_tf    # can add more...
-            
+            user_defined_TF_5: *u_tf  
             user_defined_OL_1: &u_ol
                 type: object
                 desctiption: User defined open loop signal to a defined actuator, only 1 for now
@@ -2065,8 +2062,7 @@ properties:
             user_defined_OL_2: *u_ol
             user_defined_OL_3: *u_ol
             user_defined_OL_4: *u_ol
-            user_defined_OL_5: *u_ol    # can add more...
-
+            user_defined_OL_5: *u_ol 
             user_dylib:
                 type: object
                 description: User defined dynamic library. # Not sure how to define parameters/input

--- a/windIO/turbine/IEAontology_schema.yaml
+++ b/windIO/turbine/IEAontology_schema.yaml
@@ -1658,7 +1658,7 @@ properties:
                                 description: Platform velocity feedback gain used by the ROSCO controller (https://github.com/NREL/ROSCO)
                                 unit: seconds
                             filter:
-                                $ref: "#definitions/filter"
+                                $ref: "#/definitions/filter"
                                 description: Nacelle IMU filter, used to remove tower natural frequency.  Usally a LPF or Notch Filter
 
                     twr_feedback:
@@ -1674,7 +1674,7 @@ properties:
                                 description: Tower velocity feedback gain used by the ROSCO controller (https://github.com/NREL/ROSCO)
                                 unit: seconds
                             filter:
-                                $ref: "#definitions/filter"
+                                $ref: "#/definitions/filter"
                                 description: Nacelle IMU filter, used to remove noise or amplify tower load.  Usally a HPF or Inverted Notch Filter
                     IPC:
                         type: object
@@ -1711,10 +1711,10 @@ properties:
                                 minimum: -3.14
                                 maximum: 3.14   
                             IPC_filt_1P:
-                                $ref: "#definitions/filter"
+                                $ref: "#/definitions/filter"
                                 description: Filter between tilt/yaw load and tilt/yaw pitch, usually a notch to reduce 3P, 6P frequency.
                             IPC_filt_2P:
-                                $ref: "#definitions/filter"
+                                $ref: "#/definitions/filter"
                                 description: Filter between tilt/yaw load and tilt/yaw pitch, usually a notch to reduce 3P, 6P frequency.
 
             torque:
@@ -1808,18 +1808,18 @@ properties:
                             - pitch
                         properties:
                             time:
-                                $ref: "#definitions/timeseries/time"
+                                $ref: "#/definitions/timeseries/time"
                             pitch:
-                                $ref: "#definitions/timeseries/value"
+                                $ref: "#/definitions/timeseries/value"
                     open_loop_pwr:
                         required:
                             - time
                             - power
                         properties:
                             time:
-                                $ref: "#definitions/timeseries/time"
+                                $ref: "#/definitions/timeseries/time"
                             power: 
-                                $ref: "#definitions/timeseries/value"
+                                $ref: "#/definitions/timeseries/value"
 
             wind_speed_estimator:
                 type: object
@@ -1890,7 +1890,7 @@ properties:
                             - gen_speed
                     OL_R:
                         description: Open loop power reference, for soft start-up, etc.
-                        $ref: "#definitions/timeseries"
+                        $ref: "#/definitions/timeseries"
                     reference_control:
                         type: object
                         description: Control power reference R
@@ -2005,19 +2005,19 @@ properties:
                         description: List of sensors used as control inputs, could be any OpenFAST output(?)  # DZ: within ROSCO, probably not...needs to be in avrSWAP
                         items:
                             sensor:
-                                $ref: "#definitions/sensor"
+                                $ref: "#/definitions/sensor"
                     actuators:
                         type: array
                         description: List of actuators used as control outputs
                         items:
                             actuator:
-                                $ref: "#definitions/actuator"
+                                $ref: "#/definitions/actuator"
                     control_model:
                         type: object
                         description: Linear model of controller in state-space form # MIMO harder to clearly define in transfer function form
-                        $ref: "#definitions/state_space"
+                        $ref: "#/definitions/state_space"
                     activator:
-                        $ref: "#definitions/activator"
+                        $ref: "#/definitions/activator"
 
             user_defined_SS_2: *uss
             user_defined_SS_3: *uss
@@ -2035,15 +2035,15 @@ properties:
                     - activator
                 properties:
                     sensor:
-                        $ref: "#definitions/sensor"
+                        $ref: "#/definitions/sensor"
                     actuator:
-                        $ref: "#definitions/actuator"
+                        $ref: "#/definitions/actuator"
                     control_model:
                         type: object
                         description: Linear model of controller in transfer function form, SISO only # MIMO harder to clearly define in transfer function form
-                        $ref: "#definitions/filter/filt_def/user_defined"
+                        $ref: "#/definitions/filter/filt_def/user_defined"
                     activator:
-                        $ref: "#definitions/activator"
+                        $ref: "#/definitions/activator"
             user_defined_TF_2: *u_tf
             user_defined_TF_3: *u_tf
             user_defined_TF_4: *u_tf
@@ -2059,9 +2059,9 @@ properties:
                     - optimize
                 properties:
                     actuator:
-                        $ref: "#definitions/actuator"
+                        $ref: "#/definitions/actuator"
                     timeseries:
-                        $ref: "#definitions/timeseries"           
+                        $ref: "#/definitions/timeseries"           
             user_defined_OL_2: *u_ol
             user_defined_OL_3: *u_ol
             user_defined_OL_4: *u_ol

--- a/windIO/turbine/IEAontology_schema.yaml
+++ b/windIO/turbine/IEAontology_schema.yaml
@@ -1716,6 +1716,390 @@ properties:
                             IPC_filt_2P:
                                 $ref: "#definitions/filter"
                                 description: Filter between tilt/yaw load and tilt/yaw pitch, usually a notch to reduce 3P, 6P frequency.
+
+            torque:
+                type: object
+                required:
+                    - control_type
+                    - tsr
+                    - VS_zeta
+                    - VS_omega      # DZ: I'm not sure how "required" these are or where the line is around "strongly encouraged"
+                properties:
+                    control_type:
+                        type: string
+                        description:  Type of torque control used.
+                        enum:
+                            - tsr_tracking
+                            - legacy
+                            - pi_transitions
+                    tsr:
+                        type: number
+                        description: Rated tip speed ratio of the wind turbine. As default, it is maintained constant in region II.
+                        unit: none
+                        minimum: 0
+                        maximum: 15
+                    VS_zeta:
+                        type: number
+                        description: Torque controller desired damping ratio. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                        unit: none
+                        minimum: 0
+                        maximum: 5
+                    VS_omega:
+                        type: number
+                        description: Torque controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                        unit: rad/s
+                        minimum: 0
+                        maximum: 5
+
+            setpoint_smooth:
+                type: object
+                required:
+                    - ss_vsgain
+                    - ss_pcgain
+                properties:
+                    ss_vsgain:
+                        type: number
+                        description: Torque controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                        unit: none
+                        minimum: 0
+                        maximum: 1
+                    ss_pcgain:
+                        type: number
+                        description: Pitch controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                        unit: none
+                        minimum: 0
+                        maximum: 1
+
+            shutdown:
+                type: object
+                description: Turbine shutdown control, when a certain limit is reached
+                required:
+                    - limit_type
+                    - limit_value
+                optional:
+                    - pitch_rate
+                    - open_loop_pitch
+                    - open_loop_pwr 
+                properties:
+                    limit_type:
+                        type: string
+                        description: What value is used to trigger shutdown procedure
+                        enum:
+                            - time
+                            - pitch
+                            - yaw
+                            - gen_speed
+                            - wind_speed
+                            - plt_pitch
+                            - nac_IMU
+                    limit_value:
+                        type: number
+                        description: When limit_type > limit_value, shutdown is initiated  # all the limit_types are greater than limits...but I suppose there could be less than limits
+                    pitch_rate:
+                        type: number
+                        description: Rate of pitch manuever to max_pitch. Default is 2 deg./s ?
+                        units: rad/s
+                        minimum: 0
+                        maximum: 0.2  # Technically, actuators/pitch/max_pitch_rate
+                    open_loop_pitch:
+                        type: object
+                        required:
+                            - time
+                            - pitch
+                        properties:
+                            time:
+                                $ref: "#definitions/timeseries/time"
+                            pitch:
+                                $ref: "#definitions/timeseries/value"
+                    open_loop_pwr:
+                        required:
+                            - time
+                            - power
+                        properties:
+                            time:
+                                $ref: "#definitions/timeseries/time"
+                            power: 
+                                $ref: "#definitions/timeseries/value"
+
+            wind_speed_estimator:
+                type: object
+                description: Extended Kalman filter implementation of wind speed estimator
+                optional:
+                    - gen_process_noise
+                    - turb_intensity
+                    - turb_length_scale
+                properties:
+                    gen_process_noise:
+                        type: number
+                        description: Process noise for EKF generator speed state, Default = 1e-5
+                        minimum: 0
+                        maximum: 0.001
+                    turb_intensity:
+                        type: number
+                        description: Turbulence intensity defined in usual way, parameterizes EKF process noise for wind, Default = 0.14
+                        minimum: 0
+                        maximum: 0.5
+                    turb_length_scale:
+                        type: number
+                        description: Turbulence length scale, parameterizes EKF process noise for wind, Defulat = 3 * TurbineDiameter
+                        minimum: 0
+                        maximum: 1000
+            
+            yaw:
+                type: object
+                description: Yaw control for changing wind direction or steady offset as implemented by ROSCO # there is a new method here, but using old one for now
+                required:
+                    - yaw_error_thresh
+                    - yaw_filt_fast
+                    - yaw_filt_slow
+                    - yaw_rate
+                properties:
+                    yaw_error_thresh:
+                        type: number
+                        description: Yaw error threshold, Turbine begins to yaw when it passes this
+                        unit: rad^2 s
+                        minimum: 0
+                    yaw_filt_fast:
+                        type: number
+                        description: Corner frequency for fast low pass filter, Default = 1.0 Hz
+                        unit: rad/s
+                        minimum: 0.000001
+                    yaw_filt_slow:
+                        type: number
+                        description: Corner frequency for slow low pass filter, Default = 1/60 Hz
+                        unit: rad/s
+                        minimum: 0.000000001
+                    yaw_rate:
+                        type: number
+                        description: Yaw rate when changing yaw
+                        unit: rad/s
+                        minimum: 0
+
+            power_control:
+                type: object
+                required:
+                    - method
+                optional:
+                    - OL_R
+                    - reference_control
+                properties:
+                    method:
+                        type: string
+                        description: Method used to control power output, generator speed only for now.
+                        enum:
+                            - gen_speed
+                    OL_R:
+                        description: Open loop power reference, for soft start-up, etc.
+                        $ref: "#definitions/timeseries"
+                    reference_control:
+                        type: object
+                        description: Control power reference R
+                        required:
+                            - method
+                        optional:
+                            - const_gen_est
+                            - const_gen_lim
+                            - const_gen_gain
+                            - const_plt_est
+                            - const_plt_lim
+                            - const_plt_gain                            
+                        properties:
+                            method:
+                                type: string
+                                description: Method of controlling power reference R
+                                enum:
+                                    - constrained_ref_control
+                                    - open_loop_opt    
+                            const_gen_lim:
+                                type: number
+                                description: Generator speed limit to start de-rating
+                                unit: rad/s
+                                minimum: 0
+                            const_gen_gain:
+                                type: number
+                                description: Gain for de-rating when gen speed > lim
+                                minimum: 0
+                                unit: (rad/s)^-1
+                            const_gen_est:
+                                type: number
+                                description: Generator speed transient estimation gain
+                                unit: (rad/m)
+                                minimum: 0
+                            const_plt_lim:
+                                type: number
+                                description: Platform pitch limit to start de-rating
+                                minimum: 0
+                                unit: rad
+                            const_plt_gain:
+                                type: number
+                                description: Gain for de-rating when plt pitch > lim
+                                minimum: 0
+                                unit: (rad)^-1
+                            const_plt_est:
+                                type: number
+                                description: Platform pitch transient estimation gain
+                                minimum: 0
+                                unit: (rad)/(m/s)
+
+            freq_avoidance:
+                type: object
+                description: Changes generator speed setpoint to avoid turbine natural frequencies
+                required:
+                    - list_of_freqs
+                optional:
+                    - avoidance_param
+                properties:
+                    list_of_freqs:
+                        type: array
+                        description: List of frequencies to avoid
+                        items:
+                            type: number
+                            unit: rad/s
+                            minItems: 1
+                            uniqueItems: true
+                    avoidance_param:
+                        type: array
+                        description: Buffer speed around frequencies to avoid
+                        items:
+                            type: number
+                            unit: rad/s
+                            minItems: 1
+                            uniqueItems: false
+
+            soft_cut_out:
+                type: object
+                description: Upper limit of power reference at high wind speeds (lookup table)
+                required:
+                    - wind_speeds
+                    - power_reference
+                properties:
+                    wind_speeds:
+                        type: array
+                        description: List of wind speeds
+                        items:
+                            type: number
+                            unit: m/s
+                            minItems: 1
+                            uniqueItems: true
+                    power_reference:
+                        type: array
+                        description: List of power reference at wind_speeds, number of elements should be same
+                        items:
+                            type: number
+                            unit: (-)
+                            minItems: 1
+                            uniqueItems: false
+
+            user_defined_SS_1: &uss
+                type: object
+                description: User defined state-space linear controllers within ROSCO, only 1 for now
+                required:
+                    - sensors
+                    - actuators
+                    - control_model
+                optional:
+                    - activator
+                properties:
+                    sensors:
+                        type: array
+                        description: List of sensors used as control inputs, could be any OpenFAST output(?)  # DZ: within ROSCO, probably not...needs to be in avrSWAP
+                        items:
+                            sensor:
+                                $ref: "#definitions/sensor"
+                    actuators:
+                        type: array
+                        description: List of actuators used as control outputs
+                        items:
+                            actuator:
+                                $ref: "#definitions/actuator"
+                    control_model:
+                        type: object
+                        description: Linear model of controller in state-space form # MIMO harder to clearly define in transfer function form
+                        $ref: "#definitions/state_space"
+                    activator:
+                        $ref: "#definitions/activator"
+
+            user_defined_SS_2: *uss
+            user_defined_SS_3: *uss
+            user_defined_SS_4: *uss
+            user_defined_SS_5: *uss   # can add more...
+
+            user_defined_TF_1: &u_tf
+                type: object
+                description: User defined transfer function linear controllers within ROSCO, only 1 for now
+                required:
+                    - sensor
+                    - actuator
+                    - control_model
+                optional:
+                    - activator
+                properties:
+                    sensor:
+                        $ref: "#definitions/sensor"
+                    actuator:
+                        $ref: "#definitions/actuator"
+                    control_model:
+                        type: object
+                        description: Linear model of controller in transfer function form, SISO only # MIMO harder to clearly define in transfer function form
+                        $ref: "#definitions/filter/filt_def/user_defined"
+                    activator:
+                        $ref: "#definitions/activator"
+            user_defined_TF_2: *u_tf
+            user_defined_TF_3: *u_tf
+            user_defined_TF_4: *u_tf
+            user_defined_TF_5: *u_tf    # can add more...
+            
+            user_defined_OL_1: &u_ol
+                type: object
+                desctiption: User defined open loop signal to a defined actuator, only 1 for now
+                required:
+                    - actuator
+                    - timeseries
+                optional:
+                    - optimize
+                properties:
+                    actuator:
+                        $ref: "#definitions/actuator"
+                    timeseries:
+                        $ref: "#definitions/timeseries"           
+            user_defined_OL_2: *u_ol
+            user_defined_OL_3: *u_ol
+            user_defined_OL_4: *u_ol
+            user_defined_OL_5: *u_ol    # can add more...
+
+            user_dylib:
+                type: object
+                description: User defined dynamic library. # Not sure how to define parameters/input
+                required:
+                    - dylib
+                optional:
+                    - dylib_input
+                properties:
+                    dylib:
+                        type: string
+                        description: Dynamic library file path & name
+                    dylib_input:
+                        type: string
+                        description: Dynamic library file input
+
+            user_simulink:
+                type: object
+                description: User defined simulink model
+                required:
+                    - simulink_model
+                    - matlab_path
+                optional:
+                    - sim_param_file
+                properties:
+                    simulink_model:
+                        type: string
+                        description: Path to simulink model
+                    matlab_path:
+                        type: string
+                        description: Path to matlab executable
+                    sim_param_file:
+                        type: string
+                        description: Path to matlab script with simulation parameters
     environment:
         type: object
         required:


### PR DESCRIPTION
Major changes:
- updated IEA_Ontology_schema.yaml to include remainder of control schema

Minor changes:
- updated test/turbine_example.yaml to test extra objects in control schema