### PR TITLE
Fix duplicate minimum rotor speed

### DIFF
--- a/test/turbine_example.yaml
+++ b/test/turbine_example.yaml
@@ -405,15 +405,18 @@ assembly:
 actuators:
     generator:
         rated_power: 3.37e+6
-        minOmega: 0.723
         max_torque_rate: 1.5e+6
-        maxOmega: 1.267
+        max_gen_speed: 1.267
     pitch:
         fine_pitch: 0.0174
         max_pitch_rate: 0.1221
         pitch_act_bw: 3.14
         max_pitch: 1.57 
         min_pitch: 0 
+    hss_brake:
+        torque: 1.0e+7
+        start_time: 50
+        duration: 1
 
 # Control
 control:
@@ -426,7 +429,8 @@ control:
         control_type: tsr_tracking
         tsr: 8.01754386
         VS_zeta: 1.0    
-        VS_omega: 0.2   
+        VS_omega: 0.2  
+        VS_minspd: 0.732 
     
     pitch:
         PC_zeta: 1.0    

--- a/windIO/turbine/IEAontology_schema.yaml
+++ b/windIO/turbine/IEAontology_schema.yaml
@@ -1472,6 +1472,7 @@ properties:
             - active_tension
             - passive_weather_vane  # not sure what this is, project?
             - passive_buoy_can
+            - hss_brake
         properties:
             pitch:
                 type: object
@@ -1517,23 +1518,16 @@ properties:
                 required:
                     - rated_power
                     - max_torque_rate
-                    - minOmega
-                    - maxOmega
+                    - max_gen_speed
                 properties:
                     rated_power:
                         type: number
                         description: Nameplate power of the turbine, i.e. the rated electrical output of the generator.
                         unit: W
                         minimum: 0
-                    minOmega:
+                    max_gen_speed:
                         type: number
-                        description: Minimum rotor speed of the wind turbine.
-                        unit: rad/s
-                        minimum: 0
-                        maximum: 2
-                    maxOmega:
-                        type: number
-                        description: Maximum rotor speed of the wind turbine.
+                        description: Maximum generator speed of the wind turbine.
                         unit: rad/s
                         minimum: 0
                         maximum: 10
@@ -1543,12 +1537,7 @@ properties:
                         unit: Nm/s
                         minimum: 1000
                         maximum: 100000000
-                    vs_minspd:
-                        type: number
-                        description: Minimum rotor speed. It is used by the ROSCO controller (https://github.com/NREL/ROSCO) # DZ: how is this different from minOmega?
-                        unit: rad/s
-                        minimum: 0
-                        maximum: 5
+                    
             tower_TMD:
                 type: object
                 # required:
@@ -1569,6 +1558,30 @@ properties:
                 type: object
                 # required:
                 # properties:
+            hss_brake:
+                type: object
+                required: 
+                    - start_time
+                    - duration
+                    - torque
+                properties:
+                    start_time:
+                        type: number
+                        minimum: 0
+                        unit: seconds
+                        description: Time in simulation that brake is activated, THSSBrDp in OpenFAST
+                    duration:
+                        type: number
+                        minimum: 0
+                        unit: seconds
+                        description: Time for HSS-brake to reach full deployment once initiated (sec), HSSBrDT in OpenFAST
+                    torque:
+                        type: number
+                        minimum: 0
+                        unit: N-m
+                        description: Fully deployed HSS-brake torque, HSSBrTqF in OpenFAST
+
+
     control:
         type: object
         required:
@@ -1586,6 +1599,21 @@ properties:
             - user_defined_OL
             - user_dylib
             - user_simulink
+            - user_defined_SS_1
+            - user_defined_SS_2
+            - user_defined_SS_3
+            - user_defined_SS_4
+            - user_defined_SS_5
+            - user_defined_TF_1
+            - user_defined_TF_2
+            - user_defined_TF_3
+            - user_defined_TF_4
+            - user_defined_TF_5
+            - user_defined_OL_1
+            - user_defined_OL_2
+            - user_defined_OL_3
+            - user_defined_OL_4
+            - user_defined_OL_5
         properties:
             supervisory:
                 type: object
@@ -1724,6 +1752,7 @@ properties:
                     - tsr
                     - VS_zeta
                     - VS_omega      # DZ: I'm not sure how "required" these are or where the line is around "strongly encouraged"
+                    - VS_minspd
                 properties:
                     control_type:
                         type: string
@@ -1747,6 +1776,12 @@ properties:
                     VS_omega:
                         type: number
                         description: Torque controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                        unit: rad/s
+                        minimum: 0
+                        maximum: 5
+                    VS_minspd:
+                        type: number
+                        description: Minimum rotor speed. It is used by the ROSCO controller (https://github.com/NREL/ROSCO) # DZ: how is this different from minOmega?
                         unit: rad/s
                         minimum: 0
                         maximum: 5


### PR DESCRIPTION
Resolved duplicate min rotor speed
- Moved VS_minspd to `control/torque`
- Removed minOmega from `actuator/generator`
- Renamed `maxOmega` to `max_gen_speed` and updated description

Added HSS brake to `actuator`