### PR TITLE
Build and upload package to PyPI on release

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -1,0 +1,30 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    if: github.repository_owner == 'IEAWindTask37'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
This pull request adds the GitHub Actions job to build and upload a source and binary distribution to PyPI. This is taken directly from the [FLORIS repository](https://github.com/NREL/floris/blob/main/.github/workflows/python-publish.yml). It runs after a GitHub Release is published. Note that this does not publish to conda-forge. However, users who leverage conda in their Python workflows can easily install from PyPI, but this is not true the other way around.

This functionality requires someone to be the admin of the PyPI listing. In order for this to complete successfully, the admin must provide their PyPI login information (username and password) via the GitHub Actions secrets.

This pull request addresses #19.