### PR TITLE
Fix errors when including turbine input file structure in docs

### DIFF
--- a/docs/source/airfoils.rst
+++ b/docs/source/airfoils.rst
@@ -3,9 +3,9 @@ Airfoils
 
 windIO describes the airfoils in terms of coordinates and polars. The yaml entry airfoils consists of a list of elements. 
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Airfoils
-    :end-before: # Materials
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: airfoils
+    :end-before: materials
 
 :code:`name` : String
     Label identifying the airfoils

--- a/docs/source/assembly.rst
+++ b/docs/source/assembly.rst
@@ -4,9 +4,9 @@ Assembly
 
 The field :code:`assembly` includes five entries that aim at describing the overall configuration of the wind turbine:
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Assembly
-    :end-before: # Control
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: assembly
+    :end-before: control
 
 :code:`turbine_class` : String 
     IEA wind class. The entry should be :code:`I`, :code:`II`, :code:`III`, or :code:`IV`. 

--- a/docs/source/blade.rst
+++ b/docs/source/blade.rst
@@ -9,9 +9,9 @@ outer_shape_bem
 -------------------
 :code:`outer_shape_bem` consists of a dictionary containing the data for blade BEM-based aerodynamics. 
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Blade - Outer Shape BEM
-    :end-before: # Blade - Elastic properties
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: outer_shape_bem
+    :end-before: internal_structure_2d_fem
 
 :code:`airfoil_position'labels` : Array of strings 
     The array :code:`labels` specifies the names of the airfoils to be placed along the blade. The positions are specified in the field :code:`grid`. The two arrays must share the same length and to keep an airfoil constant along blade span, this must be defined twice. The :code:`labels` must match the :code:`names` of the airfoils listed in the top level :code:`airfoils`. In between airfoils, the recommended interpolation scheme for both coordinates and polars is the Piecewise Cubic Hermite Interpolating Polynomial (PCHIP), which is implemented in `Matlab <https://www.mathworks.com/help/matlab/ref/pchip.html>`_ and in the Python library `SciPy  <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.PchipInterpolator.html>`_.
@@ -35,6 +35,13 @@ outer_shape_bem
     
     The consequences of this reference system is that standard wind turbine blades have positive twist inboard and close to zero or even slightly negative twist outboard, zero or negative x values for standard prebent blades, and positive y values for backward swept blades. The blade main direction is expressed along z, and total blade length must be computed integrating the fields x, y, and z three-dimensionally.
 
+internal structure 2d_fem
+---------------------------
+The field :code:`internal_structure_2d_fem` contains the data to describe the internal structure of standard wind turbine blades. This is a fairly sophisticated process and the ontology proposed in this work supports different definitions. On the top level, the field :code:`internal_structure_2d_fem` has three sub-components, namely the :code:`reference_axis`, which is usually defined equal to the :code:`reference_axis` in the field :code:`outer_shape_bem`, the :code:`webs`, where the positions of the shear webs are defined, and the :code:`layers`, which describe all internal layers in terms of :code:`name`, :code:`material`, :code:`thickness`, number of plies :code:`n_plies`, :code:`fiber_orientation` (for composites), and position in the two-dimensional sections. 
+
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: internal_structure_2d_fem
+    :end-before: elastic_properties_mb
 
 
 elastic properties mb 
@@ -48,18 +55,9 @@ M = [m, 0, 0, 0, 0, -mYcm, m, 0, 0, 0,mXcm, m, mYcm, -mXcm, 0, iedge, -icp, 0, i
 
 where KShrEdg and KShrFlp are the edge and flap shear stiffnesses, respectively; EA is the extension stiffness; EIEdg and EIFlp are the edge and flap stiffnesses, respectively; GJ is the torsional stiffness, m is the mass density per unit span, Xcm and Ycm are the local coordinates of the sectional center of mass, iedge and iflap are the edge and flap mass moments of inertia per unit span, iplr is the polar moment of inertia per unit span, and finally icp is the sectional cross product of inertia per unit span. Please note that for beam-like structures iplr must be equal to iedge plus iflap.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Blade - Elastic properties
-    :end-before: # Internal Structure 2D FEM
-
-internal structure 2d_fem
----------------------------
-The field :code:`internal_structure_2d_fem` contains the data to describe the internal structure of standard wind turbine blades. This is a fairly sophisticated process and the ontology proposed in this work supports different definitions. On the top level, the field :code:`internal_structure_2d_fem` has three sub-components, namely the :code:`reference_axis`, which is usually defined equal to the :code:`reference_axis` in the field :code:`outer_shape_bem`, the :code:`webs`, where the positions of the shear webs are defined, and the :code:`layers`, which describe all internal layers in terms of :code:`name`, :code:`material`, :code:`thickness`, number of plies :code:`n_plies`, :code:`fiber_orientation` (for composites), and position in the two-dimensional sections. 
-
-.. literalinclude:: ../../test/top_level.yaml
-    :start-after: # Structure
-    :end-before: # EOF3
-
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: elastic_properties_mb
+    :end-before: hub
 
 webs
 ^^^^^^^^^^
@@ -70,9 +68,9 @@ The field :code:`webs` consists of a list of entries, each representing a shear 
 
 The first (and usually most convenient) way to define the position of a shear web is by defining the fields :code:`rotation` and :code:`offset_y_pa`, which are distributed along span and are therefore described in terms of :code:`grid` and :code:`values` pairs.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Webs
-    :end-before: # Web 2
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: webs
+    :end-before: layers
 
 :code:`rotation.values` : Array of floats, rad 
     The rotation defines the angle between the chord line and the y axis and it has the opposite sign of the twist. For shear webs perpendicular to the chord line in the section(s) where twist is zero, it is easiest to simply use the keyword fixed: twist. In the example provided above, a json pointer &twist is defined.
@@ -88,9 +86,9 @@ Blades with straight shear webs will always have the field rotation equal to the
 
 The second approach to define the position of a shear web is by defining the fields :code:`start_nd_arc` and :code:`end_nd_arc`, which are also distributed along span and are therefore also described in terms of :code:`grid` and :code:`values` pairs.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Web 2
-    :end-before: # Layers
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: webs
+    :end-before: layers
 
 :code:`start_nd_arc.values` : Array of floats
     The field defines the nondimensional position along the arc of a 2D blade section, where 0 represents the trailing edge on the suction side and 1 the trailing edge on the pressure side. For flatback airfoils, the start (s = 0) and end (s = 1) nondimensional coordinate s is defined in the midpoint between suction and pressure sides. The shear webs have the field :code:`start_nd_arc` on the suction side, so usually smaller than 0.5, which approximately correspond to the leading edge.
@@ -120,13 +118,13 @@ The sub-field :code:`layers` define the layers of the wind turbine blade. In mos
 
 The position of the layer in the 2D section can be specified in various ways. If nothing is defined, this assumes that the sub-field :code:`start_nd_arc` is equal to 0 and the sub-field :code:`end_nd_arc` is equal to 1. This means that the layer wraps the whole section, such as in the example below for the outer paint. This definition of a layer should be used also for example for the outer shell skin, which tyoically wraps the whole section.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
     :start-after: # Layer 1
     :end-before: # Layer 2
 
 The most convenient approach to define the position of spar caps mimics the definition of the shear webs, adding the width and side that define the width of the layer in meters and the side where the layer is located, either “pressure” or “suction”. 
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
     :start-after: # Layer 3
     :end-before: # Layer 4
 
@@ -141,7 +139,7 @@ The most convenient approach to define the position of spar caps mimics the defi
 
 To define reinforcements, the best way is usually to define the width, in meters, and the midpoint, named :code:`midpoint_nd_arc` and defined nondimensional between 0 and 1. Converters should be able to look for the leading edge, marked as LE.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
     :start-after: # Layer 4
     :end-before: # Layer 5
 
@@ -155,7 +153,7 @@ Similar combinations can be constructed with the combination of :code:`width` an
 
 Finally, for composite layers belonging to the shear webs, a tag :code:`web` should contain the name of the web. The layers are then modeled from leading edge to trailing edge in the order they were specified.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
     :start-after: # Web layer
     :end-before: # Hub
 

--- a/docs/source/components.rst
+++ b/docs/source/components.rst
@@ -4,9 +4,9 @@ Components
 
 The inputs describing the wind turbine components are described here. The ontology windIO currently distinguishes the five components :code:`blade`, :code:`hub`, :code:`nacelle`, :code:`tower`, and :code:`foundation`
 
-.. literalinclude:: ../../test/top_level.yaml
-    :start-after: # Components
-    :end-before: # EOF2
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: components
+    :end-before: airfoils
 
 
 .. toctree::

--- a/docs/source/control.rst
+++ b/docs/source/control.rst
@@ -7,7 +7,7 @@ Actuators
 ************
 
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
     :start-after: # Actuators
     :end-before: # Control
 
@@ -98,9 +98,9 @@ Control
 ***********
 
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Control
-    :end-before: # Environment
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: control
+    :end-before: environment
 
 
 supervisory

--- a/docs/source/costs.rst
+++ b/docs/source/costs.rst
@@ -3,9 +3,8 @@ Costs
 
 The field :code:`costs` includes the data to conduct an LCOE analysis of the wind turbine. The structure of the data is based on the analysis presented in the report https://www.nrel.gov/docs/fy20osti/74598.pdf
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Costs
-    :end-before: # EOF
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: costs
 
 :code:`wake_loss_factor` : Float
     Loss factor to account for wind park losses, such as wake losses. This is used to convert the annual energy production of the turbine to the annual energy production of the wind plant.

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -3,9 +3,9 @@ Environment
 
 The field :code:`environment` includes the data characterizing air and water.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Environment
-    :end-before: # Costs
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: environment
+    :end-before: bos
 
 :code:`air_density` : Float, kg/m3
     Density of air. 

--- a/docs/source/floating.rst
+++ b/docs/source/floating.rst
@@ -7,9 +7,9 @@ Joints
 ----------------------------------------
 Joints are the *nodes* of the graph representation of the floating platform.  They must be assigned a unique name for later reference by the Members.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Floating platform
-    :end-before: # Members
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT_VolturnUS-S.yaml
+    :start-after: floating_platform
+    :end-before: members
 
 
 :code:`name` : String
@@ -80,8 +80,8 @@ Joints are the *nodes* of the graph representation of the floating platform.  Th
 Members
 ----------------------------------------
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Members
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT_VolturnUS-S.yaml
+    :start-after: members
     :end-before: # Rigid
 
 :code:`name` : String
@@ -246,7 +246,7 @@ Rigid bodies
 ----------------------------------------
 There is an allowance for additional point masses at joints with user-customized properties.  This would be useful in modeling ???.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT_VolturnUS-S.yaml
     :start-after: # Rigid
     :end-before: # Mooring
 
@@ -298,9 +298,9 @@ Mooring
 ========================================
 The mooring system ontology follows closely the input file format for MoorDyn or MAP++.  Additional information can be found in the `MoorDyn user guide <http://www.matt-hall.ca/files/MoorDyn-Users-Guide-2017-08-16.pdf>`_ .
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Mooring
-    :end-before: # Airfoils
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT_VolturnUS-S.yaml
+    :start-after: mooring
+    :end-before: airfoils
 
 nodes
 -------------

--- a/docs/source/materials.rst
+++ b/docs/source/materials.rst
@@ -3,9 +3,9 @@ Materials
 
 windIO defines a material database, which consists of a list of entries each marked by a dash. 
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Materials
-    :end-before: # Assembly
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: materials
+    :end-before: control
 
 :code:`name` : String
     Name of the material

--- a/docs/source/nacelle.rst
+++ b/docs/source/nacelle.rst
@@ -3,9 +3,9 @@ Hub
 ================
 The field :code:`hub` describes the hub system from an aeroelastic perspective, distinguishing between aerodynamic and elastic properties, added in the fields :code:`outer_shape_bem` and :code:`elastic_properties_mb` respectively.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Hub
-    :end-before: # Nacelle
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: hub
+    :end-before: nacelle
 
 :code:`diameter` : Float, m
     This is the outer diameter of the hub. It is also the diameter of the circle centered at the rotor apex and connecting the blade root centers.
@@ -31,9 +31,9 @@ Nacelle
 
 The field :code:`nacelle` describes the nacelle system from an aeroelastic perspective, distinguishing between aerodynamic and elastic properties, added in the fields :code:`outer_shape_bem` and :code:`elastic_properties_mb` respectively. An addition field :code:`drivetrain` is optional and defines some of the inputs used to size the drivetrain components.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Nacelle
-    :end-before: # end nacelle
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
+    :start-after: nacelle
+    :end-before: tower
 
 :code:`uptilt_angle` : Float, rad
     Angle between the main shaft and the horizontal plane. This is defined positive for standard upwind and downwind turbines.

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -18,8 +18,8 @@ The :code:`tower` is defined similar to the :code:`blade`.
 
 The field :code:`layers` mimic the same field of the blade.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
-    :start-after: # Tower
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT_VolturnUS-S.yaml
+    :start-after: tower
     :end-before: # Foundation
 
 Foundation
@@ -27,9 +27,9 @@ Foundation
 
 So far, :code:`foundation` is the simplest component with a single input describing the height of the foundation.
 
-.. literalinclude:: ../../test/turbine/turbine_example.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT_VolturnUS-S.yaml
     :start-after: # Foundation
-    :end-before: # Floating platform
+    :end-before: floating_platform
 
 :code:`height` : Float, m 
     Height of the foundation. Distance between ground and tower base.

--- a/docs/source/turbine.rst
+++ b/docs/source/turbine.rst
@@ -3,9 +3,8 @@ Turbine
 
 The wind turbine ontology, which is currently implemented in YAML and supported by a JSON schema, is developed defining nine top-level entries.
 
-.. literalinclude:: ../../test/top_level.yaml
+.. literalinclude:: ../../test/turbine/IEA-15-240-RWT.yaml
     :start-after: # Top level entries of the IEA Wind Task 37 wind turbine ontology
-    :end-before: # EOF
 
 
 :code:`name` : String


### PR DESCRIPTION
The Sphinx-based documentation is not currently including the turbine YAML input file snippets due to incorrect references to the example files. A few of the pages in the docs reference `test/turbine/turbine_example.yaml`, but the two test-files for the turbine ontology included in the repository are at:
- https://github.com/IEAWindTask37/windIO/blob/main/test/turbine/IEA-15-240-RWT.yaml
- https://github.com/IEAWindTask37/windIO/blob/main/test/turbine/IEA-15-240-RWT_VolturnUS-S.yaml

This pull request fixes the referenced file paths and suggests fixes for starting and stopping points for the included sections.

There are still some remaining errors, as shown below, since a few sections reference start and end points in the `literalinclude` that aren't found in the input file.

```
(windio) >>mbp@~/Development/windIO/docs (docs/yaml_include_errors *)$ make clean
Removing everything under '_build'...
(windio) >>mbp@~/Development/windIO/docs (docs/yaml_include_errors *)$ make html
Running Sphinx v7.2.6
making output directory... done
WARNING: html_static_path entry '_static' does not exist
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 18 source files that are out of date
updating environment: [new config] 18 added, 0 changed, 0 removed
reading sources... [100%] source/wind_farm
/Users/rmudafor/Development/windIO/docs/source/blade.rst:121: WARNING: start-after pattern not found: # Layer 1
/Users/rmudafor/Development/windIO/docs/source/blade.rst:127: WARNING: start-after pattern not found: # Layer 3
/Users/rmudafor/Development/windIO/docs/source/blade.rst:142: WARNING: start-after pattern not found: # Layer 4
/Users/rmudafor/Development/windIO/docs/source/blade.rst:156: WARNING: start-after pattern not found: # Web layer
/Users/rmudafor/Development/windIO/docs/source/control.rst:10: WARNING: start-after pattern not found: # Actuators
/Users/rmudafor/Development/windIO/docs/source/control.rst:130: WARNING: duplicate label pitch, other instance in /Users/rmudafor/Development/windIO/docs/source/control.rst
/Users/rmudafor/Development/windIO/docs/source/floating.rst:83: WARNING: end-before pattern not found: # Rigid
/Users/rmudafor/Development/windIO/docs/source/floating.rst:249: WARNING: start-after pattern not found: # Rigid
/Users/rmudafor/Development/windIO/docs/source/plant_energy_site.rst:17: WARNING: duplicate label properties, other instance in /Users/rmudafor/Development/windIO/docs/source/plant_energy_resource.rst
/Users/rmudafor/Development/windIO/docs/source/plant_energy_site.rst:51: WARNING: duplicate label examples, other instance in /Users/rmudafor/Development/windIO/docs/source/plant_energy_resource.rst
/Users/rmudafor/Development/windIO/docs/source/support.rst:21: WARNING: end-before pattern not found: # Foundation
/Users/rmudafor/Development/windIO/docs/source/support.rst:30: WARNING: start-after pattern not found: # Foundation
/Users/rmudafor/Development/windIO/docs/source/turbine.rst:6: WARNING: start-after pattern not found: # Top level entries of the IEA Wind Task 37 wind turbine ontology
/Users/rmudafor/Development/windIO/docs/source/wind_energy_system.rst:15: WARNING: duplicate label properties, other instance in /Users/rmudafor/Development/windIO/docs/source/plant_energy_site.rst
/Users/rmudafor/Development/windIO/docs/source/wind_energy_system.rst:35: WARNING: duplicate label examples, other instance in /Users/rmudafor/Development/windIO/docs/source/plant_energy_site.rst
/Users/rmudafor/Development/windIO/docs/source/wind_farm.rst:15: WARNING: duplicate label properties, other instance in /Users/rmudafor/Development/windIO/docs/source/wind_energy_system.rst
/Users/rmudafor/Development/windIO/docs/source/wind_farm.rst:84: WARNING: duplicate label examples, other instance in /Users/rmudafor/Development/windIO/docs/source/wind_energy_system.rst
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] source/wind_farm
generating indices... genindex done
writing additional pages... search done
copying images... [100%] source/images/stiffenerZoom.png
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 18 warnings.

The HTML pages are in _build/html.
```

@ptrbortolotti I tried to make a reasonable guess at the sections that are meant to be referenced, but you may want to review this in detail since I'm not familiar with the turbine ontology.