### PR TITLE
[BUGFIX] Fix plant initial layout schema definition and validation

### DIFF
--- a/windIO/plant/wind_energy_system.yaml
+++ b/windIO/plant/wind_energy_system.yaml
@@ -115,7 +115,7 @@ properties:
             $ref: "site.yaml#/properties/exclusions" # Or refer to subset of user defined polygons in /site/
 
     initial_design:
-      Properties:
+      properties:
         layout:
           title: Initial layout
           $ref: "wind_farm.yaml#/definition/layout"
@@ -126,7 +126,7 @@ properties:
         turbine_hub_heights:
           title: Initial turbine hub heights
     final_design:
-      Properties:
+      properties:
         layout:
           title: Final layout
           $ref: "wind_farm.yaml#/definition/layout"

--- a/windIO/plant/wind_farm.yaml
+++ b/windIO/plant/wind_farm.yaml
@@ -15,8 +15,11 @@ properties:
   #~
   layouts:
     description: Position of wind turbines
-    Properties:
-      $ref: "#/definitions/layout"
+    required:
+      - initial_layout
+    properties:
+      inital_layout:
+        $ref: "#/definitions/layout"
 
   turbines:
     description: Turbine models installed in the WES.
@@ -24,7 +27,7 @@ properties:
   #~
 
 definitions:
-  layout:
+  inital_layout:
     title: Wind turbine layout
     type: object
     required:


### PR DESCRIPTION
# Fix plant initial layout schema definition and validation
This PR fixes an error that was occurring where a wind plant file would be falsely validated if it was missing a correct `initial_layout` definition.

The `layouts` property of the `wind_farm` definition had a capital "P" Properties defined (https://github.com/IEAWindTask37/windIO/blob/main/windIO/plant/wind_farm.yaml#L18), which was ignored by the yaml module, so changing to a lower-case "p" properties caused the validation to fail properly. This issue was also found to exist in the initial and final design schemas, which has been corrected.

The additional code changes update the `wind_farm` schema so that the `initial_layout` parameter is defined, as opposed to the less clear `layout`.

## Related issue
This PR closes #50. This bug was initially identified by @amirarasteh1990 and @kilojoules.

## Impacted areas of the software
`plant/wind_farm.yaml`
`plant/wind_energy_system.yaml`